### PR TITLE
fix: ignore dist tests and fix env config for jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,13 @@ export default {
   preset: "ts-jest/presets/default-esm",
   testEnvironment: "node",
   extensionsToTreatAsEsm: [".ts"],
+
+  //roda só os testes TypeScript da pasta src
+  testMatch: ["<rootDir>/src/**/__test__/**/*.test.ts"],
+
+  //ignora qualquer coisa compilada
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+
   moduleNameMapper: {
     // Use string keys without the /.../ wrappers
     "^@config/(.*)\\.js$": "<rootDir>/src/config/$1",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,7 +1,7 @@
-import 'dotenv/config';
+import "dotenv/config";
 
 interface Config {
-  NODE_ENV: 'development' | 'production' | 'test';
+  NODE_ENV: "development" | "production" | "test";
   PORT: number;
   JWT_SECRET: string;
   RESCHEDULE_FREE_WINDOW_HOURS: number;
@@ -10,22 +10,34 @@ interface Config {
 function getEnv(): Config {
   const env = process.env;
 
-  const requiredEnvs: Array<keyof NodeJS.ProcessEnv> = [
-    'JWT_SECRET',
-    'RESCHEDULE_FREE_WINDOW_HOURS'
-  ];
+  const NODE_ENV = (env.NODE_ENV as Config["NODE_ENV"]) || "development";
+
+  // JWT sempre obrigatório
+  const requiredEnvs: Array<keyof NodeJS.ProcessEnv> = ["JWT_SECRET"];
+
+  // Só exigir RESCHEDULE_FREE_WINDOW_HOURS fora de test
+  if (NODE_ENV !== "test") {
+    requiredEnvs.push("RESCHEDULE_FREE_WINDOW_HOURS");
+  }
 
   for (const key of requiredEnvs) {
     if (!env[key]) {
-      throw new Error(`❌ Erro de Configuração: Variável ${key} não definida no .env`);
+      throw new Error(
+        `❌ Erro de Configuração: Variável ${key} não definida no .env`,
+      );
     }
   }
 
   return {
-    NODE_ENV: (env.NODE_ENV as Config['NODE_ENV']) || 'development',
-    PORT: parseInt(env.PORT || '3000', 10),
+    NODE_ENV,
+    PORT: parseInt(env.PORT || "3000", 10),
     JWT_SECRET: env.JWT_SECRET as string,
-    RESCHEDULE_FREE_WINDOW_HOURS: parseInt(env.RESCHEDULE_FREE_WINDOW_HOURS || '24', 10)
+
+    // Em test, usa default 24 se não existir
+    RESCHEDULE_FREE_WINDOW_HOURS: parseInt(
+      env.RESCHEDULE_FREE_WINDOW_HOURS || "24",
+      10,
+    ),
   };
 }
 


### PR DESCRIPTION
## O que foi feito

- Corrigida a configuração do Jest para evitar execução de testes compilados em `dist`
- Ajustada validação de variáveis de ambiente no `config.ts`
- Garantido que os testes rodem corretamente em ambiente de test
- Todos os testes unitários e de integração passando localmente

## Por que foi necessário

Após o merge da task de delete de usuário, os testes estavam falhando devido a:
- Execução duplicada de testes em `dist`
- Variável de ambiente obrigatória não configurada no contexto de testes