### PR TITLE
feat: paginate listUsers with filters by clinic

### DIFF
--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -67,14 +67,25 @@ export class UserController {
       const requester = req.user;
       const { role, search, page, pageSize } = req.query;
 
+      const pageNum = Number(page);
+      const pageSizeNum = Number(pageSize);
+      const parsedPage = Number.isFinite(pageNum) && pageNum > 0 ? pageNum : 1;
+      const parsedPageSize =
+        Number.isFinite(pageSizeNum) && pageSizeNum > 0 ? pageSizeNum : 10;
+
+      const roleFilter =
+        typeof role === "string" && role.trim() ? role.trim() : undefined;
+      const searchFilter =
+        typeof search === "string" && search.trim() ? search.trim() : undefined;
+
       const users = await this.userService.listUsersByClinic({
         clinicId,
         requester,
         filters: {
-          role: (req.query.role || "health_professional") as string,
-          search: search as string,
-          page: page ? Number(page) : 1, // Converte string para número
-          pageSize: pageSize ? Number(pageSize) : 10, // Converte string para número
+          page: parsedPage,
+          pageSize: parsedPageSize,
+          ...(roleFilter ? { role: roleFilter } : {}),
+          ...(searchFilter ? { search: searchFilter } : {}),
         },
       });
 

--- a/src/repository/user.repository.ts
+++ b/src/repository/user.repository.ts
@@ -116,12 +116,14 @@ export class UserRepository implements IUserRepository {
     await database.run(sql, [id]);
   }
 
-  //busca os usuários de uma clínica específica (from backend-main)
+  //busca os usuarios de uma cl�nica espec�fica (from backend-main)
   async findByClinicId(clinicId: number): Promise<User[]> {
-    // TODO: Voltar aqui depois de implementar o clinic_id
-    // const sql = `SELECT * FROM users WHERE clinic_id = ? ORDER BY id ASC`;
-    const sql = `SELECT * FROM users ORDER BY id ASC`;
-    return await database.query<User>(sql, /*[clinicId]*/);
+    const sql = `
+      SELECT * FROM users
+      WHERE clinic_id = ? AND deleted_at IS NULL
+      ORDER BY id ASC
+    `;
+    return await database.query<User>(sql, [clinicId]);
   }
 
   async listByClinicIdPaginated(


### PR DESCRIPTION
Task: 3.1.4 - Implementar listUsers(filters, page, pageSize) com paginação

Descrição:

- Implementa paginação e filtros (role, search) no endpoint de listagem de usuários por clínica
- Ajusta repository para filtrar por clinic_id e ignorar deleted_at
- Atualiza parsing de page e pageSize no controller
