### PR TITLE
feat(cache): add professionals and availability cache system

### DIFF
--- a/PROGRESS-backend-integration.md
+++ b/PROGRESS-backend-integration.md
@@ -124,3 +124,24 @@
 - **RN-03 (Máximo 90 dias)**: Validado pelo backend.
 - **RN-04 (Sem duplicidade)**: Erro `DUPLICATE_APPOINTMENT` quando já existe consulta com mesmo profissional na data.
 - **RN-05 (Cancelamento/Reembolso)**: >24h = 100%, <24h = 70%. Modal exibe informações de reembolso retornadas pelo backend.
+
+## 2026-01-29 Session Notes (Cache de Profissionais e Slots)
+
+### Implementações Realizadas
+
+- **`src/services/professionalsService.ts`**:
+  - Sistema de cache com TTL configurável (profissionais: 5min, slots: 2min)
+  - `professionalsCache` - cache para lista de profissionais por filtro
+  - `availabilityCache` - cache para slots de disponibilidade por profissional
+  - Funções de invalidação: `clearProfessionalsCache()`, `clearAvailabilityCache(professionalId?)`, `clearAllCaches()`
+  - Opção `{ skipCache: true }` para forçar requisição à API
+
+- **`src/pages/scheduleAppointment.ts`**:
+  - Invalidação automática do cache de disponibilidade após cancelamento
+  - Invalidação do cache do profissional específico após reagendamento
+
+### Benefícios
+
+- Redução de chamadas à API ao navegar entre filtros e datas
+- Cache automático expira após TTL (não precisa de invalidação manual para dados desatualizados)
+- Invalidação seletiva após operações que modificam disponibilidade

--- a/src/pages/scheduleAppointment.ts
+++ b/src/pages/scheduleAppointment.ts
@@ -6,6 +6,7 @@ import {
   rescheduleAppointment,
 } from "../services/appointmentsService"
 import {
+  clearAvailabilityCache,
   getProfessionalAvailability,
   listProfessionals,
 } from "../services/professionalsService"
@@ -920,6 +921,7 @@ function createCancelModal(
     uiStore.addToast("success", `Agendamento cancelado com sucesso.${refundInfo}`)
     renderToasts()
     modal.remove()
+    clearAvailabilityCache() // Invalidar cache de disponibilidade
     await loadPatientAppointments()
   })
 
@@ -1039,6 +1041,7 @@ function createRescheduleModal(
     )
     renderToasts()
     modal.remove()
+    clearAvailabilityCache(professionalId) // Invalidar cache do profissional
     await loadPatientAppointments()
   })
 


### PR DESCRIPTION
## Summary

Implementa sistema de cache para reduzir chamadas repetidas à API ao navegar entre filtros e datas.

### Funcionalidades

- **Cache com TTL**: Profissionais (5min) e Slots (2min)
- **Invalidação automática**: Cache limpo após cancelamento/reagendamento
- **Invalidação seletiva**: `clearAvailabilityCache(professionalId)` para limpar apenas slots de um profissional
- **Skip cache**: Opção `{ skipCache: true }` para forçar requisição à API

### Arquivos Modificados

| Arquivo | Mudança |
|---------|---------|
| `src/services/professionalsService.ts` | Sistema de cache + funções de invalidação |
| `src/pages/scheduleAppointment.ts` | Invalidação após cancel/reschedule |

## Test Plan

- [ ] Verificar que listagem de profissionais usa cache na segunda requisição
- [ ] Verificar que slots são cacheados ao clicar "Ver calendário"
- [ ] Confirmar invalidação do cache após cancelar agendamento
- [ ] Confirmar invalidação do cache após reagendar consulta

🤖 Generated with [Claude Code](https://claude.com/claude-code)