### PR TITLE
fix(uploads): Add write permission check and UPLOADS_PATH support

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import path from "path";
 
 interface Config {
   NODE_ENV: "development" | "production" | "test";
@@ -9,6 +10,8 @@ interface Config {
   EMAIL_TO: string;
   ENABLE_EMAIL: boolean;
   RESCHEDULE_FREE_WINDOW_HOURS: number;
+  ALLOWED_ORIGINS: string[];
+  UPLOADS_PATH: string;
 }
 
 function getEnv(): Config {
@@ -46,6 +49,17 @@ function getEnv(): Config {
       env.RESCHEDULE_FREE_WINDOW_HOURS || "24",
       10,
     ),
+    ALLOWED_ORIGINS: env.ALLOWED_ORIGINS
+      ? env.ALLOWED_ORIGINS.split(",").map((origin) => origin.trim())
+      : [
+        "http://localhost:8081",
+        "http://localhost:8080",
+        "http://localhost:3000",
+        "http://localhost:80",
+        "https://localhost:443",
+      ],
+    UPLOADS_PATH:
+      env.UPLOADS_PATH || path.join(process.cwd(), "uploads"),
   };
 }
 


### PR DESCRIPTION
This PR enhances server reliability by ensuring the uploads directory is writable at startup and allowing a custom path via the UPLOADS_PATH environment variable.