### PR TITLE
fix: improve my-appointments theme contrast

### DIFF
--- a/css/components/appointment-card.css
+++ b/css/components/appointment-card.css
@@ -235,7 +235,7 @@
   gap: 0.5rem;
   font-size: 1rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--text-primary);
   white-space: nowrap;
   /* Prevent wrapping generally */
   overflow: hidden;
@@ -257,7 +257,7 @@
 .info-card__status {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .status-pill {

--- a/css/pages/my-appointments.css
+++ b/css/pages/my-appointments.css
@@ -4,6 +4,17 @@
   /* Container specific styles if needed */
 }
 
+:root[data-theme="dark"] .my-appointments-page .appointment-card__doctor-name,
+:root[data-theme="dark"] .my-appointments-page .info-card__value,
+:root[data-theme="dark"] .my-appointments-page .info-card__status {
+  color: #e5e7eb;
+}
+
+:root[data-theme="light"] .my-appointments-page .appointment-card__doctor-name,
+:root[data-theme="light"] .my-appointments-page .info-card__value,
+:root[data-theme="light"] .my-appointments-page .info-card__status {
+  color: #374151;
+}
 .appointments-list {
   display: flex;
   flex-direction: column;
@@ -82,7 +93,7 @@
 .appointment-card__doctor-name {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #ffffff;
+  color: var(--text-primary);
   margin: 0;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontendFolder",
+  "name": "MedClinic_Project",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1168,7 +1168,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1195,7 +1194,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1432,7 +1430,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3686,7 +3683,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3745,7 +3741,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4833,8 +4828,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -5007,7 +5001,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -5057,7 +5050,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/pages/my-appointments.html
+++ b/pages/my-appointments.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="../css/components/toasts.css">
 </head>
 
-<body class="dashboard-body">
+<body class="dashboard-body my-appointments-page">
     <!-- Header -->
     <header class="patient-header">
         <div class="header-container">

--- a/src/pages/appointmentModal.ts
+++ b/src/pages/appointmentModal.ts
@@ -116,9 +116,6 @@ function renderDetailsContent(appointment: AppointmentSummary) {
             <span class="info-card__label">Situação</span>
             <div class="info-card__status">${formatStatus(appointment.status)}</div>
           </div>
-          <span class="status-pill ${getStatusPillClass(appointment.status)}">
-            ${appointment.status.toUpperCase()}
-          </span>
         </div>
       </div>
     </div>
@@ -260,13 +257,15 @@ function formatStatus(status: string) {
     scheduled: 'Agendada',
     confirmed: 'Confirmada',
     completed: 'Realizada',
-    cancelled: 'Cancelada'
+    cancelled: 'Cancelada',
+    waiting: 'Aguardando'
   }
   return map[status] || status
 }
 
 function getStatusPillClass(status: string) {
   if (['scheduled', 'confirmed'].includes(status)) return 'status-pill--confirmed'
+  if (status === 'waiting') return 'status-pill--confirmed'
   if (status === 'completed') return 'status-pill--completed'
   return 'status-pill--cancelled'
 }

--- a/src/pages/myAppointments.ts
+++ b/src/pages/myAppointments.ts
@@ -267,6 +267,7 @@ function getStatusBadge(status: string) {
     cancelled_by_patient: "status-badge--cancelled",
     cancelled_by_clinic: "status-badge--cancelled",
     completed: "status-badge--completed",
+    waiting: "status-badge--scheduled",
   }
   return map[status] ?? ""
 }
@@ -278,6 +279,7 @@ function getStatusLabel(status: string) {
     completed: "Realizado",
     cancelled_by_patient: "Cancelado",
     cancelled_by_clinic: "Cancelado",
+    waiting: "Aguardando",
   }
   return map[status] ?? status
 }


### PR DESCRIPTION
fix: melhorar contraste na tela de consultas

Descrição:

- Ajusta o contraste dos textos dos cards no tema claro e escuro.
- Padroniza o status “waiting” para “Aguardando” na lista e no modal.
- Remove o pill duplicado de status no modal de detalhes.