### PR TITLE
feat(frontend): add build:server03 script and dynamic public path sup...

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   },
   "devDependencies": {
     "copy-webpack-plugin": "^13.0.1",
+    "cross-env": "^10.1.0",
     "css-loader": "^7.1.3",
     "html-webpack-plugin": "^5.6.6",
     "mini-css-extract-plugin": "^2.10.0",
@@ -14,6 +15,7 @@
   },
   "scripts": {
     "build": "webpack --mode production",
+    "build:server03": "cross-env CLINIC_BASE_PATH=/server03/ CLINIC_API_HOST=/server03/api/v1/1 webpack --mode production",
     "dev": "webpack serve --mode development"
   },
   "browserslist": [

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,3 +1,15 @@
+// Polyfill for crypto.randomUUID in insecure contexts (HTTP)
+if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
+  // @ts-ignore
+  (crypto as any).randomUUID = () => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  };
+}
+
 type ToastLevel = "info" | "success" | "warning" | "error"
 
 export interface ToastMessage {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = (env, argv) => {
       path: path.resolve(__dirname, 'dist'),
       filename: 'js/[name].[contenthash:8].js',
       clean: true,
-      publicPath: '/'
+      publicPath: process.env.CLINIC_BASE_PATH || '/'
     },
     module: {
       rules: [
@@ -67,61 +67,62 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         template: './index.html',
         filename: 'index.html',
-        chunks: ['theme', 'main']
+        chunks: ['theme', 'main'],
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/schedule-appointment.html',
         filename: 'pages/schedule-appointment.html',
         chunks: ['theme', 'scheduleAppointment'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/login.html',
         filename: 'pages/login.html',
         chunks: ['theme', 'login'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/register.html',
         filename: 'pages/register.html',
         chunks: ['theme', 'register'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/my-appointments.html',
         filename: 'pages/my-appointments.html',
         chunks: ['theme', 'myAppointments'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/exams.html',
         filename: 'pages/exams.html',
         chunks: ['theme', 'examsPage'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/my-exams.html',
         filename: 'pages/my-exams.html',
         chunks: ['theme', 'myExams'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/agenda.html',
         filename: 'pages/agenda.html',
         chunks: ['theme', 'agenda'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/dashboard.html',
         filename: 'pages/dashboard.html',
         chunks: ['theme', 'dashboard'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       new HtmlWebpackPlugin({
         template: './pages/pep.html',
         filename: 'pages/pep.html',
         chunks: ['theme', 'pep'],
-        publicPath: '/'
+        publicPath: process.env.CLINIC_BASE_PATH || '/'
       }),
       ...mainPages.map(
         page =>
@@ -142,7 +143,7 @@ module.exports = (env, argv) => {
               ...(page === 'lab-dashboard.html' ? ['labDashboard'] : []),
               ...(page === 'users.html' ? ['usersPage'] : [])
             ],
-            publicPath: '/'
+            publicPath: process.env.CLINIC_BASE_PATH || '/'
           })
       ),
       new CopyWebpackPlugin({


### PR DESCRIPTION
…port

- Update webpack.config.js to respect CLINIC_BASE_PATH
- Add 'build:server03' script to package.json for easy deployment
- Include crypto.randomUUID polyfill
- Configured for subpath deployment (e.g. /server03/)