### PR TITLE
feat(webpack): use auto publicPath for universal deployment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = (env, argv) => {
       path: path.resolve(__dirname, 'dist'),
       filename: 'js/[name].[contenthash:8].js',
       clean: true,
-      publicPath: process.env.CLINIC_BASE_PATH || '/'
+      publicPath: 'auto'
     },
     module: {
       rules: [


### PR DESCRIPTION
- Changed publicPath from dynamic to 'auto'
- Now works in both root (/) and subpath (/server03/) contexts
- Single build serves all deployment scenarios