### PR TITLE
style: update branding and sidebar logos

### DIFF
--- a/css/components/sidebar.css
+++ b/css/components/sidebar.css
@@ -25,18 +25,18 @@
     flex-direction: column;
     align-items: center;
     text-decoration: none;
-    color: #ffffff;
+    color: var(--text-secondary);
 }
 
 .brand-icon-box {
     width: 2.5rem;
     height: 2.5rem;
     border-radius: 0.75rem;
-    background-color: var(--primary);
+    background: transparent;
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 4px 12px rgba(25, 127, 230, 0.3);
+    box-shadow: none;
     margin-bottom: 0.5rem;
 }
 
@@ -44,6 +44,7 @@
     font-size: 1.125rem;
     font-weight: 700;
     letter-spacing: -0.025em;
+    color: var(--text-secondary);
 }
 
 .sidebar-nav {

--- a/css/layout/admin-common.css
+++ b/css/layout/admin-common.css
@@ -54,15 +54,22 @@
   width: 2rem;
   height: 2rem;
   border-radius: 0.5rem;
-  background-color: var(--primary);
+  background: transparent;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 4px 12px rgba(25, 127, 230, 0.3);
+  box-shadow: none;
 }
 
 .brand-icon-box .material-symbols-outlined {
   color: #ffffff;
+}
+
+.brand-icon-box img {
+  width: 24px;
+  height: 24px;
+  display: block;
+  object-fit: contain;
 }
 
 .brand-name {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "copy-webpack-plugin": "^13.0.1",
+        "cross-env": "^10.1.0",
         "css-loader": "^7.1.3",
         "html-webpack-plugin": "^5.6.6",
         "mini-css-extract-plugin": "^2.10.0",
@@ -27,6 +28,13 @@
       "engines": {
         "node": ">=14.17.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -1805,6 +1813,24 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/src/components/Sidebar.ts
+++ b/src/components/Sidebar.ts
@@ -24,12 +24,16 @@ export class Sidebar {
     private generateHTML(): string {
         const { brand, items, userProfile } = this.options;
 
+        const brandIcon = brand.icon && (brand.icon.includes("/") || brand.icon.includes(".png") || brand.icon.includes(".svg"))
+            ? `<img src="${brand.icon}" alt="" aria-hidden="true" width="24" height="24" />`
+            : `<span class="material-symbols-outlined">${brand.icon}</span>`;
+
         return `
       <!-- Sidebar Header -->
       <div class="${this.getHeaderClass()}">
         <a href="${brand.href || '#'}" class="${this.getBrandClass()}">
           <div class="brand-icon-box">
-            <span class="material-symbols-outlined">${brand.icon}</span>
+            ${brandIcon}
           </div>
           <span class="brand-name">${brand.name}</span>
         </a>

--- a/src/pages/labDashboard.ts
+++ b/src/pages/labDashboard.ts
@@ -36,7 +36,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const sidebar = new Sidebar({
     brand: {
       name: 'MedClinic',
-      icon: 'local_hospital',
+      icon: '../assets/icons/icon-plus.png',
       href: '#'
     },
     items: sidebarItems,


### PR DESCRIPTION
style: ajustes de branding no setor de exames

Descrição:

- Atualiza a logo para usar [icon-plus.png](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/rafae/.vscode/extensions/openai.chatgpt-0.4.68-win32-x64/webview/#) nas telas do laboratório/solicitações.
- Remove o quadrado azul de fundo no sidebar do setor de exames.
- Padroniza a cor do “MedClinic” para text-secondary.