### PR TITLE
chore: remove lab dashboard date

### DIFF
--- a/pages/lab-dashboard.html
+++ b/pages/lab-dashboard.html
@@ -33,7 +33,6 @@
             <div class="admin-right">
                 <div class="header-info-right">
                     <button class="theme-toggle" id="theme-toggle" title="Alternar tema"></button>
-                    <span class="admin-header-subtitle">Terça, 15 Out 2024</span>
                 </div>
 
             </div>


### PR DESCRIPTION
chore: remove data do header do laboratório

Descrição:

- Remove a data fixa do canto superior direito na tela “Central de Exames”.
- Mantém o header limpo para uso futuro sem informação estática.