### PR TITLE
fix: translate waiting status and adjust exams header

### DIFF
--- a/css/pages/my-exams.css
+++ b/css/pages/my-exams.css
@@ -53,6 +53,10 @@
   /* slightly darker header */
 }
 
+:root[data-theme="light"] .exams-table__header {
+  background-color: #ffffff;
+}
+
 .exams-table__th {
   padding: 1rem 1.5rem;
   text-align: left;

--- a/src/pages/patientDashboard.ts
+++ b/src/pages/patientDashboard.ts
@@ -467,6 +467,7 @@ function formatStatus(status: string) {
     completed: "Realizada",
     cancelled_by_patient: "Cancelada",
     cancelled_by_clinic: "Cancelada",
+    waiting: "Aguardando",
   }
 
   return map[status] ?? status


### PR DESCRIPTION
fix: status “waiting” em português e ajuste do cabeçalho em exames

Descrição

- Traduzi o status waiting na atividade recente do paciente para “Aguardando”
- Ajustei o cabeçalho da tabela de exames para ficar branco no tema claro